### PR TITLE
Historic calendar use standard eras

### DIFF
--- a/calendars.js
+++ b/calendars.js
@@ -376,9 +376,7 @@ export class WesternCalendar { // Framework for calendars of European countries,
 	eras = ["BC", "AS", "NS"]	// define before partsFormat in order to refer to it.
 	canvas = "gregory"
 	stringFormat = "fields"	// formatting options differ from base calendars
-	partsFormat = {
-		era : { mode : "list", codes : this.eras, source : this.eras }
-	}
+	// partsFormat = {	era : { mode : "list", codes : this.eras, source : this.eras }	} // by not defining this object, displayed eras are only BC and AD.
 	firstSwitchDate = new Date ("1582-10-15T00:00:00Z") // First date of A.S. or N.S. era
 	julianCalendar = new JulianCalendar (this.id) 
 	gregorianCalendar = new GregorianCalendar (this.id)


### PR DESCRIPTION
Historic calendar manages 3 eras (BC, Ancient Style, New Style) but displays only two (BC and AD) of any language. However the standard string shows the 3 eras.

However, with the eraDisplay option, the AD era is displayed if date is AD but before date of switching to Gregorian.

This is a very common way of displaying dates in the historic calendars.